### PR TITLE
打包图片文件时路径错误输出为[object-module]

### DIFF
--- a/webpack/webpack.base.js
+++ b/webpack/webpack.base.js
@@ -27,6 +27,7 @@ module.exports = {
             options: {
               name: '[name]_[hash].[ext]',
               outputPath: 'images/',
+              esModule: false
             },
           },
         ],


### PR DESCRIPTION
打包图片文件时路径错误输出为[object-module]
![image](https://user-images.githubusercontent.com/11898652/131955944-e462aacc-1b12-455f-87cc-966a73bd93ef.png)
