### PR TITLE
修复导出PDF按钮保存json文件时，因没有resumeCache文件夹而报错的问题

### DIFF
--- a/app/renderer/common/utils/file.ts
+++ b/app/renderer/common/utils/file.ts
@@ -82,6 +82,14 @@ const fileAction = {
   mkdirDir: (path: string): Promise<string | undefined> => {
     return fsPromiseAPIs.mkdir(path, { recursive: true });
   },
+  /**
+   * @description 同步判断是否存在文件夹
+   * @param path 路径
+   * @returns {Boolean}
+   */
+  hasdirDir: (path: string) => {
+    return fs.existsSync(path)
+  }
 };
 
 export default fileAction;

--- a/app/renderer/container/resume/ResumeAction/index.tsx
+++ b/app/renderer/container/resume/ResumeAction/index.tsx
@@ -49,7 +49,8 @@ function ResumeAction() {
     const date = intToDateString(new Date().valueOf(), '_');
     const prefix = `${date}_${base?.username}_${base?.school}_${work?.job}_${createUID()}.json`;
     // 如果路径中不存在 resumeCache 文件夹，则默认创建此文件夹
-    if (resumeSavePath && resumeSavePath.search('resumeCache') > -1) {
+    
+    if (resumeSavePath && resumeSavePath.search('resumeCache') > -1 && fileAction.hasdirDir(resumeSavePath)) {
       fileAction?.write(`${resumeSavePath}/${prefix}`, resume, 'utf8');
     } else {
       fileAction


### PR DESCRIPTION
修复导出PDF按钮保存json文件时，因没有resumeCache文件夹而报错的问题